### PR TITLE
fix dependency link to ai-safety-gridworlds in setup.py

### DIFF
--- a/safe_grid_gym/envs/gridworlds_env.py
+++ b/safe_grid_gym/envs/gridworlds_env.py
@@ -38,6 +38,7 @@ class GridworldEnv(gym.Env):
                         - 'safe_interruptibility'
                         - 'side_effects_sokoban'
                         - 'tomato_watering'
+                        - 'tomato_crmdp'
                         - 'absent_supervisor'
                         - 'whisky_gold'
     cheat (bool): if set to True, the hidden reward will be returned to the agent
@@ -192,7 +193,9 @@ class GridworldsActionSpace(gym.Space):
 class GridworldsObservationSpace(gym.Space):
     def __init__(self, env):
         self.observation_spec_dict = env.observation_spec()
-        super(GridworldsObservationSpace, self)
+        shape = self.observation_spec_dict["board"].shape
+        dtype = self.observation_spec_dict["board"].dtype
+        super(GridworldsObservationSpace, self).__init__(shape=shape, dtype=dtype)
 
     def sample(self):
         """

--- a/safe_grid_gym/envs/gridworlds_env.py
+++ b/safe_grid_gym/envs/gridworlds_env.py
@@ -174,6 +174,7 @@ class GridworldsActionSpace(gym.Space):
         assert len(action_spec.shape) == 1 and action_spec.shape[0] == 1
         self.min_action = action_spec.minimum
         self.max_action = action_spec.maximum
+        self.n = (self.max_action - self.min_action) + 1
         super(GridworldsActionSpace, self).__init__(
             shape=action_spec.shape, dtype=action_spec.dtype
         )

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,8 @@ setuptools.setup(
         "rl "
         "reinforcement learning "
     ),
-    install_requires=["gym", "ai-safety-gridworlds", "numpy==1.14.5"],
-    dependency_links=["https://github.com/jvmancuso/ai-safety-gridworlds/"],
+    install_requires=["gym", "ai-safety-gridworlds", "numpy>=1.14.5"],
+    dependency_links=["https://github.com/jvmancuso/ai-safety-gridworlds/tarball/master#egg=ai-safety-gridworlds-1.2"],
     packages=setuptools.find_packages(),
     zip_safe=True,
     entry_points={},

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         "reinforcement learning "
     ),
     install_requires=["gym", "ai-safety-gridworlds", "numpy>=1.14.5"],
-    dependency_links=["https://github.com/jvmancuso/ai-safety-gridworlds/tarball/master#egg=ai-safety-gridworlds-1.2"],
+    dependency_links=["https://github.com/jvmancuso/ai-safety-gridworlds/tarball/master#egg=ai-safety-gridworlds-1.2.1"],
     packages=setuptools.find_packages(),
     zip_safe=True,
     entry_points={},

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         "reinforcement learning "
     ),
     install_requires=["gym", "ai-safety-gridworlds", "numpy>=1.14.5"],
-    dependency_links=["https://github.com/jvmancuso/ai-safety-gridworlds/tarball/master#egg=ai-safety-gridworlds-1.2.1"],
+    dependency_links=["https://github.com/jvmancuso/ai-safety-gridworlds/tarball/master#egg=ai-safety-gridworlds-1.2.2"],
     packages=setuptools.find_packages(),
     zip_safe=True,
     entry_points={},


### PR DESCRIPTION
dependency link for jvmancuso/ai-safety-gridworlds was pointing to a URL without an egg (had tried through both `python setup.py develop` and `pip install -e .`)