### PR TITLE
Fix observation space shape for toy environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ venv.bak/
 
 # direnv
 .envrc
+
+plots/

--- a/safe_grid_gym/envs/common/base_gridworld.py
+++ b/safe_grid_gym/envs/common/base_gridworld.py
@@ -41,9 +41,10 @@ class BaseGridworld(gym.Env):
     ):
         self.action_space = spaces.Discrete(4)
         assert field_types >= 1
-        self.observation_space = spaces.MultiDiscrete(
-            np.zeros(grid_shape) + field_types + 1
-        )  # All field types plus the agent's position
+        # All field types plus the agent's position
+        obs_space = np.zeros(grid_shape) + field_types + 1
+        obs_space = np.reshape(obs_space, [1] + list(obs_space.shape))
+        self.observation_space = spaces.MultiDiscrete(obs_space)
 
         self.grid_shape = grid_shape
         self.field_types = field_types

--- a/safe_grid_gym/tests/test_toy_gridworlds.py
+++ b/safe_grid_gym/tests/test_toy_gridworlds.py
@@ -72,12 +72,14 @@ class ToyGridworldsTestCase(unittest.TestCase):
                 # test onservation shapes
                 self.assertEqual(len(env.observation_space.shape), 3)
                 self.assertEqual(len(obs.shape), 3)
+                self.assertTrue(env.observation_space.contains(obs))
 
                 while not done:
                     action = env.action_space.sample()
                     actions[i].append(action)
                     obs, reward, done, info = env.step(action)
                     self.assertEqual(len(obs.shape), 3)
+                    self.assertTrue(env.observation_space.contains(obs))
 
                 # sampled actions should be the same because each run has the same seed
                 self.assertEqual(actions[i], actions[0])
@@ -188,3 +190,16 @@ class ToyGridworldsTestCase(unittest.TestCase):
                 rgb_list.append(rgb)
 
         self._check_rgb(rgb_list)
+
+    def testObservationSpaceConsistent(self):
+        """ Make sure that sampled observations are contained in the observation space. """
+        for gym_env_id in TOY_GRIDWORLDS:
+            random.seed(42)
+            np.random.seed(42)
+            env = gym.make(gym_env_id)
+            env.seed(42)
+            env.observation_space.seed(42)
+            N = 20
+            for i in range(N):
+                obs = env.observation_space.sample()
+                self.assertTrue(env.observation_space.contains(obs))

--- a/safe_grid_gym/tests/test_toy_gridworlds.py
+++ b/safe_grid_gym/tests/test_toy_gridworlds.py
@@ -65,14 +65,19 @@ class ToyGridworldsTestCase(unittest.TestCase):
                 env.seed(42)
                 env.action_space.seed(42)
                 env.observation_space.seed(42)
-                env.reset()
+                obs = env.reset()
                 actions.append([])
                 done = False
+
+                # test onservation shapes
+                self.assertEqual(len(env.observation_space.shape), 3)
+                self.assertEqual(len(obs.shape), 3)
 
                 while not done:
                     action = env.action_space.sample()
                     actions[i].append(action)
                     obs, reward, done, info = env.step(action)
+                    self.assertEqual(len(obs.shape), 3)
 
                 # sampled actions should be the same because each run has the same seed
                 self.assertEqual(actions[i], actions[0])

--- a/safe_grid_gym/tests/test_toy_gridworlds.py
+++ b/safe_grid_gym/tests/test_toy_gridworlds.py
@@ -4,7 +4,6 @@ import numpy as np
 import matplotlib
 import random
 
-
 from safe_grid_gym.envs.common.base_gridworld import UP, DOWN, LEFT, RIGHT
 from safe_grid_gym.envs.common.interface import INFO_HIDDEN_REWARD
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
         "reinforcement learning "
     ),
     install_requires=[
-        "gym",
+        "gym>=0.12",
         "ai-safety-gridworlds @ https://github.com/jvmancuso/ai-safety-gridworlds/tarball/master#egg=ai-safety-gridworlds-1.2.2",
         "numpy>=1.14.5",
         "pillow",


### PR DESCRIPTION
Fixes https://github.com/jvmancuso/safe-grid-agents/issues/66 by adding an additional dimension to the observation space of the toy environments in order to be consistent with the other environments.

Also, I tried to reproduce https://github.com/david-lindner/safe-grid-gym/issues/26 with a new test case, but was unable to do so.